### PR TITLE
修复小bug

### DIFF
--- a/src/Http/Controllers/DataDictionaryController.php
+++ b/src/Http/Controllers/DataDictionaryController.php
@@ -41,9 +41,9 @@ class DataDictionaryController extends Controller
     public function export(Request $request)
     {
         $tables = explode(',', $request->get('table'));
-
-        if (empty($tables)) {
-            return;
+        
+        if ($tables[0] == '') {
+            return '没有选择任何数据表';
         }
 
         $dump = '';


### PR DESCRIPTION
解决empty无法检测$tables,使用分割函数，$tables会生成带下标的空数组。